### PR TITLE
Dynamic classpath in schemacrawler.cmd

### DIFF
--- a/schemacrawler-distrib/src/assembly/schemacrawler.cmd
+++ b/schemacrawler-distrib/src/assembly/schemacrawler.cmd
@@ -1,1 +1,1 @@
-@java -classpath lib/*;config;. schemacrawler.Main %*
+@java -classpath %~dp0/lib/*;%~dp0/config;. schemacrawler.Main %*


### PR DESCRIPTION
This should provide a fix to #168

With this fix, it will be possible to run schemacrawler from any dir.