### PR TITLE
Have clear error message when an output format is not supported

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,3 +12,6 @@ indent_size = 4
 
 [*.md]
 trim_trailing_whitespace = false
+
+[*.sh]
+end_of_line = lf

--- a/schemacrawler-commandline/src/test/java/schemacrawler/test/utility/TestCommandProvider.java
+++ b/schemacrawler-commandline/src/test/java/schemacrawler/test/utility/TestCommandProvider.java
@@ -58,15 +58,6 @@ public class TestCommandProvider
   }
 
   @Override
-  public boolean supportsSchemaCrawlerCommand(final String command,
-                                              final SchemaCrawlerOptions schemaCrawlerOptions,
-                                              final Config additionalConfiguration,
-                                              final OutputOptions outputOptions)
-  {
-    return false;
-  }
-
-  @Override
   public boolean supportsOutputFormat(final String command,
                                       final OutputOptions outputOptions)
   {

--- a/schemacrawler-commandline/src/test/java/schemacrawler/test/utility/TestCommandProvider.java
+++ b/schemacrawler-commandline/src/test/java/schemacrawler/test/utility/TestCommandProvider.java
@@ -67,6 +67,13 @@ public class TestCommandProvider
   }
 
   @Override
+  public boolean supportsOutputFormat(final String command,
+                                      final OutputOptions outputOptions)
+  {
+    return false;
+  }
+
+  @Override
   public PluginCommand getCommandLineCommand()
   {
     final PluginCommand pluginCommand =

--- a/schemacrawler-diagram/src/main/java/schemacrawler/tools/integration/diagram/DiagramCommandProvider.java
+++ b/schemacrawler-diagram/src/main/java/schemacrawler/tools/integration/diagram/DiagramCommandProvider.java
@@ -58,6 +58,13 @@ public final class DiagramCommandProvider
                                               final Config additionalConfiguration,
                                               final OutputOptions outputOptions)
   {
+    return supportsCommand(command);
+  }
+
+  @Override
+  public boolean supportsOutputFormat(final String command,
+                                      final OutputOptions outputOptions)
+  {
     if (outputOptions == null)
     {
       return false;
@@ -69,12 +76,10 @@ public final class DiagramCommandProvider
     }
     final DiagramOutputFormat diagramOutputFormat =
       DiagramOutputFormat.fromFormat(format);
-    final boolean supportsSchemaCrawlerCommand = supportsCommand(command)
-                                                 && DiagramOutputFormat.isSupportedFormat(
-      format)
-                                                 && diagramOutputFormat
-                                                    != DiagramOutputFormat.htmlx;
-    return supportsSchemaCrawlerCommand;
+    final boolean supportsOutputFormat =
+      DiagramOutputFormat.isSupportedFormat(format)
+      && diagramOutputFormat != DiagramOutputFormat.htmlx;
+    return supportsOutputFormat;
   }
 
 }

--- a/schemacrawler-diagram/src/main/java/schemacrawler/tools/integration/diagram/DiagramCommandProvider.java
+++ b/schemacrawler-diagram/src/main/java/schemacrawler/tools/integration/diagram/DiagramCommandProvider.java
@@ -28,10 +28,6 @@ http://www.gnu.org/licenses/
 package schemacrawler.tools.integration.diagram;
 
 
-import static sf.util.Utility.isBlank;
-
-import schemacrawler.schemacrawler.Config;
-import schemacrawler.schemacrawler.SchemaCrawlerOptions;
 import schemacrawler.tools.executable.BaseCommandProvider;
 import schemacrawler.tools.executable.CommandProviderUtility;
 import schemacrawler.tools.executable.SchemaCrawlerCommand;
@@ -53,33 +49,17 @@ public final class DiagramCommandProvider
   }
 
   @Override
-  public boolean supportsSchemaCrawlerCommand(final String command,
-                                              final SchemaCrawlerOptions schemaCrawlerOptions,
-                                              final Config additionalConfiguration,
-                                              final OutputOptions outputOptions)
-  {
-    return supportsCommand(command);
-  }
-
-  @Override
   public boolean supportsOutputFormat(final String command,
                                       final OutputOptions outputOptions)
   {
-    if (outputOptions == null)
-    {
-      return false;
-    }
-    final String format = outputOptions.getOutputFormatValue();
-    if (isBlank(format))
-    {
-      return false;
-    }
-    final DiagramOutputFormat diagramOutputFormat =
-      DiagramOutputFormat.fromFormat(format);
-    final boolean supportsOutputFormat =
-      DiagramOutputFormat.isSupportedFormat(format)
-      && diagramOutputFormat != DiagramOutputFormat.htmlx;
-    return supportsOutputFormat;
+    return supportsOutputFormat(command, outputOptions, format -> {
+      final DiagramOutputFormat diagramOutputFormat =
+        DiagramOutputFormat.fromFormat(format);
+      final boolean supportsOutputFormat =
+        DiagramOutputFormat.isSupportedFormat(format)
+        && diagramOutputFormat != DiagramOutputFormat.htmlx;
+      return supportsOutputFormat;
+    });
   }
 
 }

--- a/schemacrawler-diagram/src/main/java/schemacrawler/tools/integration/embeddeddiagram/EmbeddedDiagramCommandProvider.java
+++ b/schemacrawler-diagram/src/main/java/schemacrawler/tools/integration/embeddeddiagram/EmbeddedDiagramCommandProvider.java
@@ -59,6 +59,13 @@ public final class EmbeddedDiagramCommandProvider
                                               final Config additionalConfiguration,
                                               final OutputOptions outputOptions)
   {
+    return supportsCommand(command);
+  }
+
+  @Override
+  public boolean supportsOutputFormat(final String command,
+                                      final OutputOptions outputOptions)
+  {
     if (outputOptions == null)
     {
       return false;
@@ -70,10 +77,9 @@ public final class EmbeddedDiagramCommandProvider
     }
     final DiagramOutputFormat diagramOutputFormat =
       DiagramOutputFormat.fromFormat(format);
-    final boolean supportsSchemaCrawlerCommand = supportsCommand(command)
-                                                 && diagramOutputFormat
-                                                    == DiagramOutputFormat.htmlx;
-    return supportsSchemaCrawlerCommand;
+    final boolean supportsOutputFormat =
+      diagramOutputFormat == DiagramOutputFormat.htmlx;
+    return supportsOutputFormat;
   }
 
 }

--- a/schemacrawler-diagram/src/main/java/schemacrawler/tools/integration/embeddeddiagram/EmbeddedDiagramCommandProvider.java
+++ b/schemacrawler-diagram/src/main/java/schemacrawler/tools/integration/embeddeddiagram/EmbeddedDiagramCommandProvider.java
@@ -28,10 +28,6 @@ http://www.gnu.org/licenses/
 package schemacrawler.tools.integration.embeddeddiagram;
 
 
-import static sf.util.Utility.isBlank;
-
-import schemacrawler.schemacrawler.Config;
-import schemacrawler.schemacrawler.SchemaCrawlerOptions;
 import schemacrawler.tools.executable.BaseCommandProvider;
 import schemacrawler.tools.executable.CommandProviderUtility;
 import schemacrawler.tools.executable.SchemaCrawlerCommand;
@@ -54,32 +50,16 @@ public final class EmbeddedDiagramCommandProvider
   }
 
   @Override
-  public boolean supportsSchemaCrawlerCommand(final String command,
-                                              final SchemaCrawlerOptions schemaCrawlerOptions,
-                                              final Config additionalConfiguration,
-                                              final OutputOptions outputOptions)
-  {
-    return supportsCommand(command);
-  }
-
-  @Override
   public boolean supportsOutputFormat(final String command,
                                       final OutputOptions outputOptions)
   {
-    if (outputOptions == null)
-    {
-      return false;
-    }
-    final String format = outputOptions.getOutputFormatValue();
-    if (isBlank(format))
-    {
-      return false;
-    }
-    final DiagramOutputFormat diagramOutputFormat =
-      DiagramOutputFormat.fromFormat(format);
-    final boolean supportsOutputFormat =
-      diagramOutputFormat == DiagramOutputFormat.htmlx;
-    return supportsOutputFormat;
+    return supportsOutputFormat(command, outputOptions, format -> {
+      final DiagramOutputFormat diagramOutputFormat =
+        DiagramOutputFormat.fromFormat(format);
+      final boolean supportsOutputFormat =
+        diagramOutputFormat == DiagramOutputFormat.htmlx;
+      return supportsOutputFormat;
+    });
   }
 
 }

--- a/schemacrawler-lint/src/main/java/schemacrawler/tools/lint/executable/LintCommandProvider.java
+++ b/schemacrawler-lint/src/main/java/schemacrawler/tools/lint/executable/LintCommandProvider.java
@@ -29,12 +29,9 @@ package schemacrawler.tools.lint.executable;
 
 
 import static schemacrawler.tools.executable.commandline.PluginCommand.newPluginCommand;
-import static sf.util.Utility.isBlank;
 
 import java.nio.file.Path;
 
-import schemacrawler.schemacrawler.Config;
-import schemacrawler.schemacrawler.SchemaCrawlerOptions;
 import schemacrawler.tools.executable.BaseCommandProvider;
 import schemacrawler.tools.executable.CommandDescription;
 import schemacrawler.tools.executable.SchemaCrawlerCommand;
@@ -62,30 +59,12 @@ public class LintCommandProvider
   }
 
   @Override
-  public boolean supportsSchemaCrawlerCommand(final String command,
-                                              final SchemaCrawlerOptions schemaCrawlerOptions,
-                                              final Config additionalConfiguration,
-                                              final OutputOptions outputOptions)
-  {
-    return supportsCommand(command);
-  }
-
-  @Override
   public boolean supportsOutputFormat(final String command,
                                       final OutputOptions outputOptions)
   {
-    if (outputOptions == null)
-    {
-      return false;
-    }
-    final String format = outputOptions.getOutputFormatValue();
-    if (isBlank(format))
-    {
-      return false;
-    }
-    final boolean supportsOutputFormat =
-      LintReportOutputFormat.isSupportedFormat(format);
-    return supportsOutputFormat;
+    return supportsOutputFormat(command,
+                                outputOptions,
+                                LintReportOutputFormat::isSupportedFormat);
   }
 
   @Override

--- a/schemacrawler-lint/src/main/java/schemacrawler/tools/lint/executable/LintCommandProvider.java
+++ b/schemacrawler-lint/src/main/java/schemacrawler/tools/lint/executable/LintCommandProvider.java
@@ -67,6 +67,13 @@ public class LintCommandProvider
                                               final Config additionalConfiguration,
                                               final OutputOptions outputOptions)
   {
+    return supportsCommand(command);
+  }
+
+  @Override
+  public boolean supportsOutputFormat(final String command,
+                                      final OutputOptions outputOptions)
+  {
     if (outputOptions == null)
     {
       return false;
@@ -76,10 +83,9 @@ public class LintCommandProvider
     {
       return false;
     }
-    final boolean supportsSchemaCrawlerCommand =
-      supportsCommand(command) && LintReportOutputFormat.isSupportedFormat(
-        format);
-    return supportsSchemaCrawlerCommand;
+    final boolean supportsOutputFormat =
+      LintReportOutputFormat.isSupportedFormat(format);
+    return supportsOutputFormat;
   }
 
   @Override

--- a/schemacrawler-scripting/src/main/java/schemacrawler/tools/integration/script/ScriptCommandProvider.java
+++ b/schemacrawler-scripting/src/main/java/schemacrawler/tools/integration/script/ScriptCommandProvider.java
@@ -58,15 +58,6 @@ public class ScriptCommandProvider
   }
 
   @Override
-  public boolean supportsSchemaCrawlerCommand(final String command,
-                                              final SchemaCrawlerOptions schemaCrawlerOptions,
-                                              final Config additionalConfiguration,
-                                              final OutputOptions outputOptions)
-  {
-    return supportsCommand(command);
-  }
-
-  @Override
   public boolean supportsOutputFormat(final String command,
                                       final OutputOptions outputOptions)
   {

--- a/schemacrawler-scripting/src/main/java/schemacrawler/tools/integration/script/ScriptCommandProvider.java
+++ b/schemacrawler-scripting/src/main/java/schemacrawler/tools/integration/script/ScriptCommandProvider.java
@@ -67,6 +67,13 @@ public class ScriptCommandProvider
   }
 
   @Override
+  public boolean supportsOutputFormat(final String command,
+                                      final OutputOptions outputOptions)
+  {
+    return true;
+  }
+
+  @Override
   public PluginCommand getCommandLineCommand()
   {
     final PluginCommand pluginCommand =

--- a/schemacrawler-scripting/src/main/java/schemacrawler/tools/integration/serialize/SerializationCommandProvider.java
+++ b/schemacrawler-scripting/src/main/java/schemacrawler/tools/integration/serialize/SerializationCommandProvider.java
@@ -64,6 +64,13 @@ public class SerializationCommandProvider
                                               final Config additionalConfiguration,
                                               final OutputOptions outputOptions)
   {
+    return supportsCommand(command);
+  }
+
+  @Override
+  public boolean supportsOutputFormat(final String command,
+                                      final OutputOptions outputOptions)
+  {
     if (outputOptions == null)
     {
       return false;
@@ -73,9 +80,9 @@ public class SerializationCommandProvider
     {
       return false;
     }
-    final boolean supportsSchemaCrawlerCommand =
-      supportsCommand(command) && SerializationFormat.isSupportedFormat(format);
-    return supportsSchemaCrawlerCommand;
+    final boolean supportsOutputFormat =
+      SerializationFormat.isSupportedFormat(format);
+    return supportsOutputFormat;
   }
 
   @Override

--- a/schemacrawler-scripting/src/main/java/schemacrawler/tools/integration/serialize/SerializationCommandProvider.java
+++ b/schemacrawler-scripting/src/main/java/schemacrawler/tools/integration/serialize/SerializationCommandProvider.java
@@ -29,10 +29,7 @@ package schemacrawler.tools.integration.serialize;
 
 
 import static schemacrawler.tools.executable.commandline.PluginCommand.newPluginCommand;
-import static sf.util.Utility.isBlank;
 
-import schemacrawler.schemacrawler.Config;
-import schemacrawler.schemacrawler.SchemaCrawlerOptions;
 import schemacrawler.tools.executable.BaseCommandProvider;
 import schemacrawler.tools.executable.CommandDescription;
 import schemacrawler.tools.executable.SchemaCrawlerCommand;
@@ -59,30 +56,12 @@ public class SerializationCommandProvider
   }
 
   @Override
-  public boolean supportsSchemaCrawlerCommand(final String command,
-                                              final SchemaCrawlerOptions schemaCrawlerOptions,
-                                              final Config additionalConfiguration,
-                                              final OutputOptions outputOptions)
-  {
-    return supportsCommand(command);
-  }
-
-  @Override
   public boolean supportsOutputFormat(final String command,
                                       final OutputOptions outputOptions)
   {
-    if (outputOptions == null)
-    {
-      return false;
-    }
-    final String format = outputOptions.getOutputFormatValue();
-    if (isBlank(format))
-    {
-      return false;
-    }
-    final boolean supportsOutputFormat =
-      SerializationFormat.isSupportedFormat(format);
-    return supportsOutputFormat;
+    return supportsOutputFormat(command,
+                                outputOptions,
+                                SerializationFormat::isSupportedFormat);
   }
 
   @Override

--- a/schemacrawler-scripting/src/main/java/schemacrawler/tools/integration/template/TemplateCommandProvider.java
+++ b/schemacrawler-scripting/src/main/java/schemacrawler/tools/integration/template/TemplateCommandProvider.java
@@ -58,15 +58,6 @@ public class TemplateCommandProvider
   }
 
   @Override
-  public boolean supportsSchemaCrawlerCommand(final String command,
-                                              final SchemaCrawlerOptions schemaCrawlerOptions,
-                                              final Config additionalConfiguration,
-                                              final OutputOptions outputOptions)
-  {
-    return supportsCommand(command);
-  }
-
-  @Override
   public boolean supportsOutputFormat(final String command,
                                       final OutputOptions outputOptions)
   {

--- a/schemacrawler-scripting/src/main/java/schemacrawler/tools/integration/template/TemplateCommandProvider.java
+++ b/schemacrawler-scripting/src/main/java/schemacrawler/tools/integration/template/TemplateCommandProvider.java
@@ -67,6 +67,13 @@ public class TemplateCommandProvider
   }
 
   @Override
+  public boolean supportsOutputFormat(final String command,
+                                      final OutputOptions outputOptions)
+  {
+    return true;
+  }
+
+  @Override
   public PluginCommand getCommandLineCommand()
   {
     final PluginCommand pluginCommand =

--- a/schemacrawler-tools/src/main/java/schemacrawler/tools/executable/BaseCommandProvider.java
+++ b/schemacrawler-tools/src/main/java/schemacrawler/tools/executable/BaseCommandProvider.java
@@ -34,8 +34,12 @@ import static sf.util.Utility.isBlank;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.function.Predicate;
 
+import schemacrawler.schemacrawler.Config;
+import schemacrawler.schemacrawler.SchemaCrawlerOptions;
 import schemacrawler.tools.executable.commandline.PluginCommand;
+import schemacrawler.tools.options.OutputOptions;
 
 public abstract class BaseCommandProvider
   implements CommandProvider
@@ -58,6 +62,33 @@ public abstract class BaseCommandProvider
   public final Collection<CommandDescription> getSupportedCommands()
   {
     return new ArrayList<>(supportedCommands);
+  }
+
+  @Override
+  public boolean supportsSchemaCrawlerCommand(final String command,
+                                              final SchemaCrawlerOptions schemaCrawlerOptions,
+                                              final Config additionalConfiguration,
+                                              final OutputOptions outputOptions)
+  {
+    return supportsCommand(command);
+  }
+
+  protected boolean supportsOutputFormat(final String command,
+                                         final OutputOptions outputOptions,
+                                         final Predicate<String> outputFormatValuePredicate)
+  {
+    requireNonNull(outputFormatValuePredicate,
+                   "No output format value predicate provided");
+    if (outputOptions == null)
+    {
+      return false;
+    }
+    final String format = outputOptions.getOutputFormatValue();
+    if (isBlank(format))
+    {
+      return false;
+    }
+    return outputFormatValuePredicate.test(format);
   }
 
   @Override

--- a/schemacrawler-tools/src/main/java/schemacrawler/tools/executable/CommandProvider.java
+++ b/schemacrawler-tools/src/main/java/schemacrawler/tools/executable/CommandProvider.java
@@ -49,6 +49,9 @@ public interface CommandProvider
                                        Config additionalConfiguration,
                                        OutputOptions outputOptions);
 
+  boolean supportsOutputFormat(String command,
+                               OutputOptions outputOptions);
+
   PluginCommand getCommandLineCommand();
 
 }

--- a/schemacrawler-tools/src/main/java/schemacrawler/tools/executable/CommandRegistry.java
+++ b/schemacrawler-tools/src/main/java/schemacrawler/tools/executable/CommandRegistry.java
@@ -161,6 +161,12 @@ public final class CommandRegistry
       throw new SchemaCrawlerException(String.format("Unknown command <%s>",
                                                      command));
     }
+    if (!executableCommandProvider.supportsOutputFormat(command, outputOptions))
+    {
+      throw new SchemaCrawlerException(String.format("Output format <%s> not supported for command <%s>",
+                                                     outputOptions.getOutputFormatValue(),
+                                                     command));
+    }
 
     final SchemaCrawlerCommand scCommand;
     try

--- a/schemacrawler-tools/src/main/java/schemacrawler/tools/executable/CommandRegistry.java
+++ b/schemacrawler-tools/src/main/java/schemacrawler/tools/executable/CommandRegistry.java
@@ -34,6 +34,7 @@ import static java.util.Comparator.naturalOrder;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.ServiceLoader;
 import java.util.logging.Level;
@@ -57,6 +58,7 @@ public final class CommandRegistry
 
   private static final SchemaCrawlerLogger LOGGER =
     SchemaCrawlerLogger.getLogger(CommandRegistry.class.getName());
+  private static CommandRegistry commandRegistrySingleton;
 
   public static CommandRegistry getCommandRegistry()
     throws SchemaCrawlerException
@@ -101,9 +103,6 @@ public final class CommandRegistry
 
     return commandProviders;
   }
-
-  private static CommandRegistry commandRegistrySingleton;
-
   private final List<CommandProvider> commandRegistry;
 
   private CommandRegistry()
@@ -143,30 +142,18 @@ public final class CommandRegistry
                                            final OutputOptions outputOptions)
     throws SchemaCrawlerException
   {
-    CommandProvider executableCommandProvider = null;
-    for (final CommandProvider commandProvider : commandRegistry)
-    {
-      if (commandProvider.supportsSchemaCrawlerCommand(command,
-                                                       schemaCrawlerOptions,
-                                                       additionalConfiguration,
-                                                       outputOptions))
-      {
+    final List<CommandProvider> executableCommandProviders = new ArrayList<>();
+    findSupportedCommands(command,
+                          schemaCrawlerOptions,
+                          additionalConfiguration,
+                          outputOptions,
+                          executableCommandProviders);
+    findSupportedOutputFormats(command,
+                               outputOptions,
+                               executableCommandProviders);
 
-        executableCommandProvider = commandProvider;
-        break;
-      }
-    }
-    if (executableCommandProvider == null)
-    {
-      throw new SchemaCrawlerException(String.format("Unknown command <%s>",
-                                                     command));
-    }
-    if (!executableCommandProvider.supportsOutputFormat(command, outputOptions))
-    {
-      throw new SchemaCrawlerException(String.format("Output format <%s> not supported for command <%s>",
-                                                     outputOptions.getOutputFormatValue(),
-                                                     command));
-    }
+    final CommandProvider executableCommandProvider =
+      executableCommandProviders.get(0);
 
     final SchemaCrawlerCommand scCommand;
     try
@@ -186,6 +173,55 @@ public final class CommandRegistry
     }
 
     return scCommand;
+  }
+
+  private void findSupportedOutputFormats(final String command,
+                                          final OutputOptions outputOptions,
+                                          final List<CommandProvider> executableCommandProviders)
+    throws SchemaCrawlerException
+  {
+    final Iterator<CommandProvider> iterator =
+      executableCommandProviders.iterator();
+    while (iterator.hasNext())
+    {
+      final CommandProvider executableCommandProvider = iterator.next();
+      if (!executableCommandProvider.supportsOutputFormat(command,
+                                                          outputOptions))
+      {
+        iterator.remove();
+      }
+    }
+    if (executableCommandProviders.isEmpty())
+    {
+      throw new SchemaCrawlerException(String.format(
+        "Output format <%s> not supported for command <%s>",
+        outputOptions.getOutputFormatValue(),
+        command));
+    }
+  }
+
+  private void findSupportedCommands(final String command,
+                                     final SchemaCrawlerOptions schemaCrawlerOptions,
+                                     final Config additionalConfiguration,
+                                     final OutputOptions outputOptions,
+                                     final List<CommandProvider> executableCommandProviders)
+    throws SchemaCrawlerException
+  {
+    for (final CommandProvider commandProvider : commandRegistry)
+    {
+      if (commandProvider.supportsSchemaCrawlerCommand(command,
+                                                       schemaCrawlerOptions,
+                                                       additionalConfiguration,
+                                                       outputOptions))
+      {
+        executableCommandProviders.add(commandProvider);
+      }
+    }
+    if (executableCommandProviders.isEmpty())
+    {
+      throw new SchemaCrawlerException(String.format("Unknown command <%s>",
+                                                     command));
+    }
   }
 
 }

--- a/schemacrawler-tools/src/main/java/schemacrawler/tools/executable/OperationCommandProvider.java
+++ b/schemacrawler-tools/src/main/java/schemacrawler/tools/executable/OperationCommandProvider.java
@@ -33,6 +33,7 @@ import static sf.util.Utility.isBlank;
 import schemacrawler.schemacrawler.Config;
 import schemacrawler.schemacrawler.SchemaCrawlerOptions;
 import schemacrawler.tools.options.OutputOptions;
+import schemacrawler.tools.options.TextOutputFormat;
 import schemacrawler.tools.text.operation.OperationCommand;
 
 final class OperationCommandProvider
@@ -86,6 +87,24 @@ final class OperationCommandProvider
     // So no check is done for output format.
     final boolean supportsSchemaCrawlerCommand = isOperation || isNamedQuery;
     return supportsSchemaCrawlerCommand;
+  }
+
+  @Override
+  public boolean supportsOutputFormat(final String command,
+                                      final OutputOptions outputOptions)
+  {
+    if (outputOptions == null)
+    {
+      return false;
+    }
+    final String format = outputOptions.getOutputFormatValue();
+    if (isBlank(format))
+    {
+      return false;
+    }
+    final boolean supportsOutputFormat =
+      TextOutputFormat.isSupportedFormat(format);
+    return supportsOutputFormat;
   }
 
 }

--- a/schemacrawler-tools/src/main/java/schemacrawler/tools/executable/OperationCommandProvider.java
+++ b/schemacrawler-tools/src/main/java/schemacrawler/tools/executable/OperationCommandProvider.java
@@ -57,16 +57,6 @@ final class OperationCommandProvider
                                               final Config additionalConfiguration,
                                               final OutputOptions outputOptions)
   {
-    if (outputOptions == null)
-    {
-      return false;
-    }
-    final String format = outputOptions.getOutputFormatValue();
-    if (isBlank(format))
-    {
-      return false;
-    }
-
     // Check if the command is an operation
     final boolean isOperation = supportsCommand(command);
 
@@ -93,18 +83,7 @@ final class OperationCommandProvider
   public boolean supportsOutputFormat(final String command,
                                       final OutputOptions outputOptions)
   {
-    if (outputOptions == null)
-    {
-      return false;
-    }
-    final String format = outputOptions.getOutputFormatValue();
-    if (isBlank(format))
-    {
-      return false;
-    }
-    final boolean supportsOutputFormat =
-      TextOutputFormat.isSupportedFormat(format);
-    return supportsOutputFormat;
+    return true;
   }
 
 }

--- a/schemacrawler-tools/src/main/java/schemacrawler/tools/executable/SchemaTextCommandProvider.java
+++ b/schemacrawler-tools/src/main/java/schemacrawler/tools/executable/SchemaTextCommandProvider.java
@@ -71,4 +71,22 @@ public final class SchemaTextCommandProvider
     return supportsSchemaCrawlerCommand;
   }
 
+  @Override
+  public boolean supportsOutputFormat(final String command,
+                                      final OutputOptions outputOptions)
+  {
+    if (outputOptions == null)
+    {
+      return false;
+    }
+    final String format = outputOptions.getOutputFormatValue();
+    if (isBlank(format))
+    {
+      return false;
+    }
+    final boolean supportsOutputFormat =
+      TextOutputFormat.isSupportedFormat(format);
+    return supportsOutputFormat;
+  }
+
 }

--- a/schemacrawler-tools/src/main/java/schemacrawler/tools/executable/SchemaTextCommandProvider.java
+++ b/schemacrawler-tools/src/main/java/schemacrawler/tools/executable/SchemaTextCommandProvider.java
@@ -28,10 +28,6 @@ http://www.gnu.org/licenses/
 package schemacrawler.tools.executable;
 
 
-import static sf.util.Utility.isBlank;
-
-import schemacrawler.schemacrawler.Config;
-import schemacrawler.schemacrawler.SchemaCrawlerOptions;
 import schemacrawler.tools.options.OutputOptions;
 import schemacrawler.tools.options.TextOutputFormat;
 import schemacrawler.tools.text.schema.SchemaTextRenderer;
@@ -52,41 +48,12 @@ public final class SchemaTextCommandProvider
   }
 
   @Override
-  public boolean supportsSchemaCrawlerCommand(final String command,
-                                              final SchemaCrawlerOptions schemaCrawlerOptions,
-                                              final Config additionalConfiguration,
-                                              final OutputOptions outputOptions)
-  {
-    if (outputOptions == null)
-    {
-      return false;
-    }
-    final String format = outputOptions.getOutputFormatValue();
-    if (isBlank(format))
-    {
-      return false;
-    }
-    final boolean supportsSchemaCrawlerCommand =
-      supportsCommand(command) && TextOutputFormat.isSupportedFormat(format);
-    return supportsSchemaCrawlerCommand;
-  }
-
-  @Override
   public boolean supportsOutputFormat(final String command,
                                       final OutputOptions outputOptions)
   {
-    if (outputOptions == null)
-    {
-      return false;
-    }
-    final String format = outputOptions.getOutputFormatValue();
-    if (isBlank(format))
-    {
-      return false;
-    }
-    final boolean supportsOutputFormat =
-      TextOutputFormat.isSupportedFormat(format);
-    return supportsOutputFormat;
+    return supportsOutputFormat(command,
+                                outputOptions,
+                                TextOutputFormat::isSupportedFormat);
   }
 
 }

--- a/schemacrawler/src/test/java/schemacrawler/test/Issue342Test.java
+++ b/schemacrawler/src/test/java/schemacrawler/test/Issue342Test.java
@@ -1,0 +1,66 @@
+package schemacrawler.test;
+
+
+import static java.io.File.createTempFile;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.nio.file.Path;
+import java.sql.Connection;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import schemacrawler.inclusionrule.RegularExpressionInclusionRule;
+import schemacrawler.schemacrawler.LimitOptionsBuilder;
+import schemacrawler.schemacrawler.LoadOptionsBuilder;
+import schemacrawler.schemacrawler.SchemaCrawlerException;
+import schemacrawler.schemacrawler.SchemaCrawlerOptions;
+import schemacrawler.schemacrawler.SchemaCrawlerOptionsBuilder;
+import schemacrawler.schemacrawler.SchemaInfoLevelBuilder;
+import schemacrawler.test.utility.TestDatabaseConnectionParameterResolver;
+import schemacrawler.tools.executable.SchemaCrawlerExecutable;
+import schemacrawler.tools.options.OutputOptions;
+import schemacrawler.tools.options.OutputOptionsBuilder;
+
+@ExtendWith(TestDatabaseConnectionParameterResolver.class)
+public class Issue342Test
+{
+
+  @Test
+  public void unsupportedOutputFormat(final Connection connection)
+    throws Exception
+  {
+    // Create the options
+    final LimitOptionsBuilder limitOptionsBuilder = LimitOptionsBuilder
+      .builder()
+      .includeSchemas(new RegularExpressionInclusionRule("PUBLIC.BOOKS"));
+    final LoadOptionsBuilder loadOptionsBuilder = LoadOptionsBuilder.builder()
+      // Set what details are required in the schema - this affects the
+      // time taken to crawl the schema
+      .withSchemaInfoLevel(SchemaInfoLevelBuilder.standard());
+    final SchemaCrawlerOptionsBuilder optionsBuilder =
+      SchemaCrawlerOptionsBuilder
+        .builder()
+        .withLimitOptionsBuilder(limitOptionsBuilder)
+        .withLoadOptionsBuilder(loadOptionsBuilder);
+    final SchemaCrawlerOptions options = optionsBuilder.toOptions();
+
+    final Path outputFile = createTempFile("schemacrawler", ".dat").toPath();
+    final OutputOptions outputOptions =
+      OutputOptionsBuilder.newOutputOptions("json", outputFile);
+    final String command = "schema";
+
+    final SchemaCrawlerExecutable executable =
+      new SchemaCrawlerExecutable(command);
+    executable.setSchemaCrawlerOptions(options);
+    executable.setOutputOptions(outputOptions);
+    executable.setConnection(connection);
+
+    final SchemaCrawlerException exception =
+      assertThrows(SchemaCrawlerException.class, () -> executable.execute());
+    assertThat(exception.getMessage(),
+               is("Output format <json> not supported for command <schema>"));
+  }
+
+}


### PR DESCRIPTION
Please see #342 where an attempt was made to generate JSON output using the `schema` command.