### PR TITLE
Fix flakiness in table cell test

### DIFF
--- a/schemacrawler-utility/src/test/java/us/fatehi/utility/test/html/TableCellTest.java
+++ b/schemacrawler-utility/src/test/java/us/fatehi/utility/test/html/TableCellTest.java
@@ -79,8 +79,13 @@ public class TableCellTest {
 
     assertThat(
         tablecell.render(TagOutputFormat.html),
-        is(
-            "<td colspan='2' sometag='custom&value' align='right'><b><i>display &amp; text</i></b></td>"));
+        anyOf(
+          is(
+            "<td sometag='custom&value' colspan='2' align='right'><b><i>display &amp; text</i></b></td>"
+          ),
+          is(
+            "<td colspan='2' sometag='custom&value' align='right'><b><i>display &amp; text</i></b></td>"
+          )));
     assertThat(tablecell.render(TagOutputFormat.text), is("display & text"));
     assertThat(tablecell.render(TagOutputFormat.tsv), is("display & text"));
   }


### PR DESCRIPTION
`us.fatehi.utility.test.html.TableCellTest#td2` was flaky under [NonDex](https://github.com/TestingResearchIllinois/NonDex); this change fixes the accidental dependence on the order of insertion of a `HashMap`.

In light of the "Note"—this is probably not acceptable for merging as-is anyway, and really serves as an issue with tagalong demonstration of what goes wrong.