### PR TITLE
Upgrade to Oracle Database Free

### DIFF
--- a/schemacrawler-docker-compose/oracle.yaml
+++ b/schemacrawler-docker-compose/oracle.yaml
@@ -3,8 +3,8 @@ version: '3.7'
 services:
 
   oracle:
-    # https://hub.docker.com/r/gvenzl/oracle-xe
-    image: gvenzl/oracle-xe:21-slim-faststart
+    # https://hub.docker.com/r/gvenzl/oracle-free
+    image: gvenzl/oracle-free:23-slim-faststart
     container_name: oracle
     ports:
       - target: 1521


### PR DESCRIPTION
Hey Sualesh,

Thanks a lot for using my Oracle Database images.
I have noticed that you are still using the old Oracle Database XE version of my images.

Oracle has discontinued Oracle Database XE and instead offers Oracle Database Free as the successor, which was first released last year.

The database editions are compatible, hence nothing should break or change other than the connect string and the Docker image tag.

I have taken the liberty to provide the modifications based on what I could find in the repository.
No worries if you decide to close the PR and redo the changes.

Thanks,

# Pull Request Note

I really appreciate your interest in SchemaCrawler. At this point, I am not accepting any pull requests or contributions, since I am trying to figure out copyright and/ or patent issues.

Please feel free to file bug reports and enhancement requests, though, and I will do my best to address them quickly. If you would like to suggest a change and include a patch as a proof-of-concept, that would help me better understand what is needed. However, please do not be offended if I rewrite your patch from scratch.

*Sualeh Fatehi* <sualeh@hotmail.com>
