### PR TITLE
Add coverage test for TableGrepFilter

### DIFF
--- a/schemacrawler-api/src/main/java/schemacrawler/filter/TableGrepFilter.java
+++ b/schemacrawler-api/src/main/java/schemacrawler/filter/TableGrepFilter.java
@@ -108,6 +108,7 @@ class TableGrepFilter implements Predicate<Table> {
   }
 
   private boolean checkIncludeForColumns(final Table table) {
+
     final List<Column> columns = table.getColumns();
     if (columns.isEmpty()) {
       return true;

--- a/schemacrawler-api/src/main/java/schemacrawler/filter/TableGrepFilter.java
+++ b/schemacrawler-api/src/main/java/schemacrawler/filter/TableGrepFilter.java
@@ -28,11 +28,11 @@ http://www.gnu.org/licenses/
 
 package schemacrawler.filter;
 
-import static java.util.Objects.requireNonNull;
 import java.util.List;
 import java.util.function.Predicate;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import static java.util.Objects.requireNonNull;
 import schemacrawler.inclusionrule.InclusionRule;
 import schemacrawler.schema.Column;
 import schemacrawler.schema.Table;
@@ -74,6 +74,14 @@ class TableGrepFilter implements Predicate<Table> {
     final boolean checkIncludeForDefinitions = grepDefinitionInclusionRule != null;
 
     if (!checkIncludeForTables && !checkIncludeForColumns && !checkIncludeForDefinitions) {
+      if (invertMatch) {
+        LOGGER.log(
+            Level.FINE,
+            new StringFormat(
+                "Ignoring the invert match setting for table <%s>, "
+                    + "since no inclusion rules are set",
+                table));
+      }
       return true;
     }
 
@@ -114,10 +122,8 @@ class TableGrepFilter implements Predicate<Table> {
 
   private boolean checkIncludeForDefinitions(final Table table) {
     if (grepDefinitionInclusionRule != null) {
-      if (grepDefinitionInclusionRule.test(table.getRemarks())) {
-        return true;
-      }
-      if (grepDefinitionInclusionRule.test(table.getDefinition())) {
+      if (grepDefinitionInclusionRule.test(table.getRemarks())
+          || grepDefinitionInclusionRule.test(table.getDefinition())) {
         return true;
       }
       for (final Trigger trigger : table.getTriggers()) {

--- a/schemacrawler-api/src/test/java/schemacrawler/filter/TableGrepFilterTest.java
+++ b/schemacrawler-api/src/test/java/schemacrawler/filter/TableGrepFilterTest.java
@@ -2,274 +2,108 @@ package schemacrawler.filter;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.not;
-import static org.hamcrest.Matchers.nullValue;
-
-import java.util.Collections;
-
 import org.junit.jupiter.api.Test;
-
 import schemacrawler.inclusionrule.InclusionRule;
 import schemacrawler.inclusionrule.RegularExpressionInclusionRule;
-import schemacrawler.schema.Column;
 import schemacrawler.schema.Table;
-import schemacrawler.schema.Trigger;
 import schemacrawler.schemacrawler.GrepOptions;
-import schemacrawler.schemacrawler.SchemaCrawlerOptionsBuilder;
+import schemacrawler.schemacrawler.GrepOptionsBuilder;
+import schemacrawler.test.utility.crawl.LightTable;
 
 class TableGrepFilterTest {
 
   @Test
   void testTableGrepFilter() {
-    final GrepOptions grepOptions = GrepOptions.builder().build();
+    final Table table = new LightTable("test_table");
+
+    final GrepOptions grepOptions = GrepOptionsBuilder.builder().toOptions();
     final TableGrepFilter tableGrepFilter = new TableGrepFilter(grepOptions);
-
-    final Table table = new Table() {
-      @Override
-      public String getFullName() {
-        return "test_table";
-      }
-
-      @Override
-      public String getRemarks() {
-        return "test_remarks";
-      }
-
-      @Override
-      public String getDefinition() {
-        return "test_definition";
-      }
-
-      @Override
-      public Iterable<Column> getColumns() {
-        return Collections.emptyList();
-      }
-
-      @Override
-      public Iterable<Trigger> getTriggers() {
-        return Collections.emptyList();
-      }
-    };
 
     assertThat(tableGrepFilter.test(table), is(true));
   }
 
   @Test
   void testTableGrepFilterWithInclusionRule() {
+    final Table table = new LightTable("test_table");
+
     final InclusionRule grepTableInclusionRule = new RegularExpressionInclusionRule("test_table");
-    final GrepOptions grepOptions = GrepOptions.builder().withGrepTableInclusionRule(grepTableInclusionRule).build();
+    final GrepOptions grepOptions =
+        GrepOptionsBuilder.builder().includeGreppedTables(grepTableInclusionRule).toOptions();
     final TableGrepFilter tableGrepFilter = new TableGrepFilter(grepOptions);
-
-    final Table table = new Table() {
-      @Override
-      public String getFullName() {
-        return "test_table";
-      }
-
-      @Override
-      public String getRemarks() {
-        return "test_remarks";
-      }
-
-      @Override
-      public String getDefinition() {
-        return "test_definition";
-      }
-
-      @Override
-      public Iterable<Column> getColumns() {
-        return Collections.emptyList();
-      }
-
-      @Override
-      public Iterable<Trigger> getTriggers() {
-        return Collections.emptyList();
-      }
-    };
 
     assertThat(tableGrepFilter.test(table), is(true));
   }
 
   @Test
   void testTableGrepFilterWithNonMatchingInclusionRule() {
-    final InclusionRule grepTableInclusionRule = new RegularExpressionInclusionRule("non_matching_table");
-    final GrepOptions grepOptions = GrepOptions.builder().withGrepTableInclusionRule(grepTableInclusionRule).build();
+    final Table table = new LightTable("test_table");
+
+    final InclusionRule grepTableInclusionRule =
+        new RegularExpressionInclusionRule("non_matching_table");
+    final GrepOptions grepOptions =
+        GrepOptionsBuilder.builder().includeGreppedTables(grepTableInclusionRule).toOptions();
     final TableGrepFilter tableGrepFilter = new TableGrepFilter(grepOptions);
-
-    final Table table = new Table() {
-      @Override
-      public String getFullName() {
-        return "test_table";
-      }
-
-      @Override
-      public String getRemarks() {
-        return "test_remarks";
-      }
-
-      @Override
-      public String getDefinition() {
-        return "test_definition";
-      }
-
-      @Override
-      public Iterable<Column> getColumns() {
-        return Collections.emptyList();
-      }
-
-      @Override
-      public Iterable<Trigger> getTriggers() {
-        return Collections.emptyList();
-      }
-    };
 
     assertThat(tableGrepFilter.test(table), is(false));
   }
 
   @Test
   void testTableGrepFilterWithInvertMatch() {
-    final GrepOptions grepOptions = GrepOptions.builder().withGrepInvertMatch(true).build();
+    final Table table = new LightTable("test_table");
+
+    final InclusionRule grepTableInclusionRule = new RegularExpressionInclusionRule("test_table");
+    final GrepOptions grepOptions =
+        GrepOptionsBuilder.builder()
+            .includeGreppedTables(grepTableInclusionRule)
+            .invertGrepMatch(true)
+            .toOptions();
     final TableGrepFilter tableGrepFilter = new TableGrepFilter(grepOptions);
-
-    final Table table = new Table() {
-      @Override
-      public String getFullName() {
-        return "test_table";
-      }
-
-      @Override
-      public String getRemarks() {
-        return "test_remarks";
-      }
-
-      @Override
-      public String getDefinition() {
-        return "test_definition";
-      }
-
-      @Override
-      public Iterable<Column> getColumns() {
-        return Collections.emptyList();
-      }
-
-      @Override
-      public Iterable<Trigger> getTriggers() {
-        return Collections.emptyList();
-      }
-    };
 
     assertThat(tableGrepFilter.test(table), is(false));
   }
 
   @Test
   void testTableGrepFilterWithColumnInclusionRule() {
-    final InclusionRule grepColumnInclusionRule = new RegularExpressionInclusionRule("test_column");
-    final GrepOptions grepOptions = GrepOptions.builder().withGrepColumnInclusionRule(grepColumnInclusionRule).build();
+    final LightTable table = new LightTable("test_table");
+    table.addColumn("test_column");
+
+    final InclusionRule grepColumnInclusionRule =
+        new RegularExpressionInclusionRule("test_table\\.test_column");
+    final GrepOptions grepOptions =
+        GrepOptionsBuilder.builder().includeGreppedColumns(grepColumnInclusionRule).toOptions();
     final TableGrepFilter tableGrepFilter = new TableGrepFilter(grepOptions);
-
-    final Table table = new Table() {
-      @Override
-      public String getFullName() {
-        return "test_table";
-      }
-
-      @Override
-      public String getRemarks() {
-        return "test_remarks";
-      }
-
-      @Override
-      public String getDefinition() {
-        return "test_definition";
-      }
-
-      @Override
-      public Iterable<Column> getColumns() {
-        return Collections.singletonList(new Column() {
-          @Override
-          public String getFullName() {
-            return "test_column";
-          }
-        });
-      }
-
-      @Override
-      public Iterable<Trigger> getTriggers() {
-        return Collections.emptyList();
-      }
-    };
 
     assertThat(tableGrepFilter.test(table), is(true));
   }
 
   @Test
   void testTableGrepFilterWithDefinitionInclusionRule() {
-    final InclusionRule grepDefinitionInclusionRule = new RegularExpressionInclusionRule("test_definition");
-    final GrepOptions grepOptions = GrepOptions.builder().withGrepDefinitionInclusionRule(grepDefinitionInclusionRule).build();
+    final LightTable table = new LightTable("test_table");
+    table.setDefinition("test_definition");
+
+    final InclusionRule grepDefinitionInclusionRule =
+        new RegularExpressionInclusionRule("test_definition");
+    final GrepOptions grepOptions =
+        GrepOptionsBuilder.builder()
+            .includeGreppedDefinitions(grepDefinitionInclusionRule)
+            .toOptions();
     final TableGrepFilter tableGrepFilter = new TableGrepFilter(grepOptions);
-
-    final Table table = new Table() {
-      @Override
-      public String getFullName() {
-        return "test_table";
-      }
-
-      @Override
-      public String getRemarks() {
-        return "test_remarks";
-      }
-
-      @Override
-      public String getDefinition() {
-        return "test_definition";
-      }
-
-      @Override
-      public Iterable<Column> getColumns() {
-        return Collections.emptyList();
-      }
-
-      @Override
-      public Iterable<Trigger> getTriggers() {
-        return Collections.emptyList();
-      }
-    };
 
     assertThat(tableGrepFilter.test(table), is(true));
   }
 
   @Test
   void testTableGrepFilterWithNonMatchingDefinitionInclusionRule() {
-    final InclusionRule grepDefinitionInclusionRule = new RegularExpressionInclusionRule("non_matching_definition");
-    final GrepOptions grepOptions = GrepOptions.builder().withGrepDefinitionInclusionRule(grepDefinitionInclusionRule).build();
+    final LightTable table = new LightTable("test_table");
+    table.setDefinition("test_definition");
+
+    final InclusionRule grepDefinitionInclusionRule =
+        new RegularExpressionInclusionRule("non_matching_definition");
+    final GrepOptions grepOptions =
+        GrepOptionsBuilder.builder()
+            .includeGreppedDefinitions(grepDefinitionInclusionRule)
+            .toOptions();
     final TableGrepFilter tableGrepFilter = new TableGrepFilter(grepOptions);
-
-    final Table table = new Table() {
-      @Override
-      public String getFullName() {
-        return "test_table";
-      }
-
-      @Override
-      public String getRemarks() {
-        return "test_remarks";
-      }
-
-      @Override
-      public String getDefinition() {
-        return "test_definition";
-      }
-
-      @Override
-      public Iterable<Column> getColumns() {
-        return Collections.emptyList();
-      }
-
-      @Override
-      public Iterable<Trigger> getTriggers() {
-        return Collections.emptyList();
-      }
-    };
 
     assertThat(tableGrepFilter.test(table), is(false));
   }

--- a/schemacrawler-api/src/test/java/schemacrawler/filter/TableGrepFilterTest.java
+++ b/schemacrawler-api/src/test/java/schemacrawler/filter/TableGrepFilterTest.java
@@ -2,6 +2,7 @@ package schemacrawler.filter;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import schemacrawler.inclusionrule.InclusionRule;
 import schemacrawler.inclusionrule.RegularExpressionInclusionRule;
@@ -9,13 +10,28 @@ import schemacrawler.schema.Table;
 import schemacrawler.schemacrawler.GrepOptions;
 import schemacrawler.schemacrawler.GrepOptionsBuilder;
 import schemacrawler.test.utility.crawl.LightTable;
+import schemacrawler.test.utility.crawl.LightTrigger;
 
 class TableGrepFilterTest {
 
+  private Table table;
+
+  @BeforeEach
+  public void setUp() {
+    final LightTable table = new LightTable("test_table");
+    table.addColumn("test_column");
+    table.setDefinition("test_definition");
+    table.setRemarks("test_remarks");
+
+    final LightTrigger trigger = new LightTrigger(table, "test_trigger");
+    trigger.setActionStatement("test_action_statement");
+    table.addTrigger(trigger);
+
+    this.table = table;
+  }
+
   @Test
   void testTableGrepFilter() {
-    final Table table = new LightTable("test_table");
-
     final GrepOptions grepOptions = GrepOptionsBuilder.builder().toOptions();
     final TableGrepFilter tableGrepFilter = new TableGrepFilter(grepOptions);
 
@@ -23,49 +39,19 @@ class TableGrepFilterTest {
   }
 
   @Test
-  void testTableGrepFilterWithInclusionRule() {
-    final Table table = new LightTable("test_table");
-
-    final InclusionRule grepTableInclusionRule = new RegularExpressionInclusionRule("test_table");
+  void testTableGrepFilterWithColumnInclusionRule() {
+    final InclusionRule grepColumnInclusionRule =
+        new RegularExpressionInclusionRule("test_table\\.test_column");
     final GrepOptions grepOptions =
-        GrepOptionsBuilder.builder().includeGreppedTables(grepTableInclusionRule).toOptions();
+        GrepOptionsBuilder.builder().includeGreppedColumns(grepColumnInclusionRule).toOptions();
     final TableGrepFilter tableGrepFilter = new TableGrepFilter(grepOptions);
 
     assertThat(tableGrepFilter.test(table), is(true));
   }
 
   @Test
-  void testTableGrepFilterWithNonMatchingInclusionRule() {
-    final Table table = new LightTable("test_table");
-
-    final InclusionRule grepTableInclusionRule =
-        new RegularExpressionInclusionRule("non_matching_table");
-    final GrepOptions grepOptions =
-        GrepOptionsBuilder.builder().includeGreppedTables(grepTableInclusionRule).toOptions();
-    final TableGrepFilter tableGrepFilter = new TableGrepFilter(grepOptions);
-
-    assertThat(tableGrepFilter.test(table), is(false));
-  }
-
-  @Test
-  void testTableGrepFilterWithInvertMatch() {
-    final Table table = new LightTable("test_table");
-
-    final InclusionRule grepTableInclusionRule = new RegularExpressionInclusionRule("test_table");
-    final GrepOptions grepOptions =
-        GrepOptionsBuilder.builder()
-            .includeGreppedTables(grepTableInclusionRule)
-            .invertGrepMatch(true)
-            .toOptions();
-    final TableGrepFilter tableGrepFilter = new TableGrepFilter(grepOptions);
-
-    assertThat(tableGrepFilter.test(table), is(false));
-  }
-
-  @Test
-  void testTableGrepFilterWithColumnInclusionRule() {
-    final LightTable table = new LightTable("test_table");
-    table.addColumn("test_column");
+  void testTableGrepFilterWithColumnInclusionRuleWithNoColumns() {
+    table = new LightTable("test_table");
 
     final InclusionRule grepColumnInclusionRule =
         new RegularExpressionInclusionRule("test_table\\.test_column");
@@ -78,9 +64,6 @@ class TableGrepFilterTest {
 
   @Test
   void testTableGrepFilterWithDefinitionInclusionRule() {
-    final LightTable table = new LightTable("test_table");
-    table.setDefinition("test_definition");
-
     final InclusionRule grepDefinitionInclusionRule =
         new RegularExpressionInclusionRule("test_definition");
     final GrepOptions grepOptions =
@@ -93,10 +76,62 @@ class TableGrepFilterTest {
   }
 
   @Test
-  void testTableGrepFilterWithNonMatchingDefinitionInclusionRule() {
-    final LightTable table = new LightTable("test_table");
-    table.setDefinition("test_definition");
+  void testTableGrepFilterWithInclusionRule() {
+    final InclusionRule grepTableInclusionRule = new RegularExpressionInclusionRule("test_table");
+    final GrepOptions grepOptions =
+        GrepOptionsBuilder.builder().includeGreppedTables(grepTableInclusionRule).toOptions();
+    final TableGrepFilter tableGrepFilter = new TableGrepFilter(grepOptions);
 
+    assertThat(tableGrepFilter.test(table), is(true));
+  }
+
+  @Test
+  void testTableGrepFilterWithInvertMatch() {
+    final InclusionRule grepTableInclusionRule = new RegularExpressionInclusionRule("test_table");
+    final GrepOptions grepOptions =
+        GrepOptionsBuilder.builder()
+            .includeGreppedTables(grepTableInclusionRule)
+            .invertGrepMatch(true)
+            .toOptions();
+    final TableGrepFilter tableGrepFilter = new TableGrepFilter(grepOptions);
+
+    assertThat(tableGrepFilter.test(table), is(false));
+  }
+
+  @Test
+  void testTableGrepFilterWithInvertMatchForNoMatch() {
+    final InclusionRule grepTableInclusionRule = new RegularExpressionInclusionRule("test_table_1");
+    final GrepOptions grepOptions =
+        GrepOptionsBuilder.builder()
+            .includeGreppedTables(grepTableInclusionRule)
+            .invertGrepMatch(true)
+            .toOptions();
+    final TableGrepFilter tableGrepFilter = new TableGrepFilter(grepOptions);
+
+    assertThat(tableGrepFilter.test(table), is(true));
+  }
+
+  @Test
+  void testTableGrepFilterWithJustInvertMatch() {
+    final GrepOptions grepOptions = GrepOptionsBuilder.builder().invertGrepMatch(true).toOptions();
+    final TableGrepFilter tableGrepFilter = new TableGrepFilter(grepOptions);
+
+    assertThat(tableGrepFilter.test(table), is(true));
+  }
+
+  @Test
+  void testTableGrepFilterWithNonMatchingColumnInclusionRule() {
+    final InclusionRule grepColumnInclusionRule =
+        new RegularExpressionInclusionRule("test_table\\.test_column_1");
+    final GrepOptions grepOptions =
+        GrepOptionsBuilder.builder().includeGreppedColumns(grepColumnInclusionRule).toOptions();
+    final TableGrepFilter tableGrepFilter = new TableGrepFilter(grepOptions);
+
+    assertThat(tableGrepFilter.test(table), is(false));
+  }
+
+  @Test
+  void testTableGrepFilterWithNonMatchingDefinitionInclusionRule() {
     final InclusionRule grepDefinitionInclusionRule =
         new RegularExpressionInclusionRule("non_matching_definition");
     final GrepOptions grepOptions =
@@ -106,5 +141,53 @@ class TableGrepFilterTest {
     final TableGrepFilter tableGrepFilter = new TableGrepFilter(grepOptions);
 
     assertThat(tableGrepFilter.test(table), is(false));
+  }
+
+  @Test
+  void testTableGrepFilterWithNonMatchingInclusionRule() {
+    final InclusionRule grepTableInclusionRule =
+        new RegularExpressionInclusionRule("non_matching_table");
+    final GrepOptions grepOptions =
+        GrepOptionsBuilder.builder().includeGreppedTables(grepTableInclusionRule).toOptions();
+    final TableGrepFilter tableGrepFilter = new TableGrepFilter(grepOptions);
+
+    assertThat(tableGrepFilter.test(table), is(false));
+  }
+
+  @Test
+  void testTableGrepFilterWithoutColumnInclusionRule() {
+    final InclusionRule grepColumnInclusionRule =
+        new RegularExpressionInclusionRule("test_table\\.test_column_1");
+    final GrepOptions grepOptions =
+        GrepOptionsBuilder.builder().includeGreppedColumns(grepColumnInclusionRule).toOptions();
+    final TableGrepFilter tableGrepFilter = new TableGrepFilter(grepOptions);
+
+    assertThat(tableGrepFilter.test(table), is(false));
+  }
+
+  @Test
+  void testTableGrepFilterWithRemarksInclusionRule() {
+    final InclusionRule grepDefinitionInclusionRule =
+        new RegularExpressionInclusionRule("test_remarks");
+    final GrepOptions grepOptions =
+        GrepOptionsBuilder.builder()
+            .includeGreppedDefinitions(grepDefinitionInclusionRule)
+            .toOptions();
+    final TableGrepFilter tableGrepFilter = new TableGrepFilter(grepOptions);
+
+    assertThat(tableGrepFilter.test(table), is(true));
+  }
+
+  @Test
+  void testTableGrepFilterWithTriggerActionItemInclusionRule() {
+    final InclusionRule grepDefinitionInclusionRule =
+        new RegularExpressionInclusionRule("test_action_statement");
+    final GrepOptions grepOptions =
+        GrepOptionsBuilder.builder()
+            .includeGreppedDefinitions(grepDefinitionInclusionRule)
+            .toOptions();
+    final TableGrepFilter tableGrepFilter = new TableGrepFilter(grepOptions);
+
+    assertThat(tableGrepFilter.test(table), is(true));
   }
 }

--- a/schemacrawler-api/src/test/java/schemacrawler/filter/TableGrepFilterTest.java
+++ b/schemacrawler-api/src/test/java/schemacrawler/filter/TableGrepFilterTest.java
@@ -1,0 +1,276 @@
+package schemacrawler.filter;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
+
+import java.util.Collections;
+
+import org.junit.jupiter.api.Test;
+
+import schemacrawler.inclusionrule.InclusionRule;
+import schemacrawler.inclusionrule.RegularExpressionInclusionRule;
+import schemacrawler.schema.Column;
+import schemacrawler.schema.Table;
+import schemacrawler.schema.Trigger;
+import schemacrawler.schemacrawler.GrepOptions;
+import schemacrawler.schemacrawler.SchemaCrawlerOptionsBuilder;
+
+class TableGrepFilterTest {
+
+  @Test
+  void testTableGrepFilter() {
+    final GrepOptions grepOptions = GrepOptions.builder().build();
+    final TableGrepFilter tableGrepFilter = new TableGrepFilter(grepOptions);
+
+    final Table table = new Table() {
+      @Override
+      public String getFullName() {
+        return "test_table";
+      }
+
+      @Override
+      public String getRemarks() {
+        return "test_remarks";
+      }
+
+      @Override
+      public String getDefinition() {
+        return "test_definition";
+      }
+
+      @Override
+      public Iterable<Column> getColumns() {
+        return Collections.emptyList();
+      }
+
+      @Override
+      public Iterable<Trigger> getTriggers() {
+        return Collections.emptyList();
+      }
+    };
+
+    assertThat(tableGrepFilter.test(table), is(true));
+  }
+
+  @Test
+  void testTableGrepFilterWithInclusionRule() {
+    final InclusionRule grepTableInclusionRule = new RegularExpressionInclusionRule("test_table");
+    final GrepOptions grepOptions = GrepOptions.builder().withGrepTableInclusionRule(grepTableInclusionRule).build();
+    final TableGrepFilter tableGrepFilter = new TableGrepFilter(grepOptions);
+
+    final Table table = new Table() {
+      @Override
+      public String getFullName() {
+        return "test_table";
+      }
+
+      @Override
+      public String getRemarks() {
+        return "test_remarks";
+      }
+
+      @Override
+      public String getDefinition() {
+        return "test_definition";
+      }
+
+      @Override
+      public Iterable<Column> getColumns() {
+        return Collections.emptyList();
+      }
+
+      @Override
+      public Iterable<Trigger> getTriggers() {
+        return Collections.emptyList();
+      }
+    };
+
+    assertThat(tableGrepFilter.test(table), is(true));
+  }
+
+  @Test
+  void testTableGrepFilterWithNonMatchingInclusionRule() {
+    final InclusionRule grepTableInclusionRule = new RegularExpressionInclusionRule("non_matching_table");
+    final GrepOptions grepOptions = GrepOptions.builder().withGrepTableInclusionRule(grepTableInclusionRule).build();
+    final TableGrepFilter tableGrepFilter = new TableGrepFilter(grepOptions);
+
+    final Table table = new Table() {
+      @Override
+      public String getFullName() {
+        return "test_table";
+      }
+
+      @Override
+      public String getRemarks() {
+        return "test_remarks";
+      }
+
+      @Override
+      public String getDefinition() {
+        return "test_definition";
+      }
+
+      @Override
+      public Iterable<Column> getColumns() {
+        return Collections.emptyList();
+      }
+
+      @Override
+      public Iterable<Trigger> getTriggers() {
+        return Collections.emptyList();
+      }
+    };
+
+    assertThat(tableGrepFilter.test(table), is(false));
+  }
+
+  @Test
+  void testTableGrepFilterWithInvertMatch() {
+    final GrepOptions grepOptions = GrepOptions.builder().withGrepInvertMatch(true).build();
+    final TableGrepFilter tableGrepFilter = new TableGrepFilter(grepOptions);
+
+    final Table table = new Table() {
+      @Override
+      public String getFullName() {
+        return "test_table";
+      }
+
+      @Override
+      public String getRemarks() {
+        return "test_remarks";
+      }
+
+      @Override
+      public String getDefinition() {
+        return "test_definition";
+      }
+
+      @Override
+      public Iterable<Column> getColumns() {
+        return Collections.emptyList();
+      }
+
+      @Override
+      public Iterable<Trigger> getTriggers() {
+        return Collections.emptyList();
+      }
+    };
+
+    assertThat(tableGrepFilter.test(table), is(false));
+  }
+
+  @Test
+  void testTableGrepFilterWithColumnInclusionRule() {
+    final InclusionRule grepColumnInclusionRule = new RegularExpressionInclusionRule("test_column");
+    final GrepOptions grepOptions = GrepOptions.builder().withGrepColumnInclusionRule(grepColumnInclusionRule).build();
+    final TableGrepFilter tableGrepFilter = new TableGrepFilter(grepOptions);
+
+    final Table table = new Table() {
+      @Override
+      public String getFullName() {
+        return "test_table";
+      }
+
+      @Override
+      public String getRemarks() {
+        return "test_remarks";
+      }
+
+      @Override
+      public String getDefinition() {
+        return "test_definition";
+      }
+
+      @Override
+      public Iterable<Column> getColumns() {
+        return Collections.singletonList(new Column() {
+          @Override
+          public String getFullName() {
+            return "test_column";
+          }
+        });
+      }
+
+      @Override
+      public Iterable<Trigger> getTriggers() {
+        return Collections.emptyList();
+      }
+    };
+
+    assertThat(tableGrepFilter.test(table), is(true));
+  }
+
+  @Test
+  void testTableGrepFilterWithDefinitionInclusionRule() {
+    final InclusionRule grepDefinitionInclusionRule = new RegularExpressionInclusionRule("test_definition");
+    final GrepOptions grepOptions = GrepOptions.builder().withGrepDefinitionInclusionRule(grepDefinitionInclusionRule).build();
+    final TableGrepFilter tableGrepFilter = new TableGrepFilter(grepOptions);
+
+    final Table table = new Table() {
+      @Override
+      public String getFullName() {
+        return "test_table";
+      }
+
+      @Override
+      public String getRemarks() {
+        return "test_remarks";
+      }
+
+      @Override
+      public String getDefinition() {
+        return "test_definition";
+      }
+
+      @Override
+      public Iterable<Column> getColumns() {
+        return Collections.emptyList();
+      }
+
+      @Override
+      public Iterable<Trigger> getTriggers() {
+        return Collections.emptyList();
+      }
+    };
+
+    assertThat(tableGrepFilter.test(table), is(true));
+  }
+
+  @Test
+  void testTableGrepFilterWithNonMatchingDefinitionInclusionRule() {
+    final InclusionRule grepDefinitionInclusionRule = new RegularExpressionInclusionRule("non_matching_definition");
+    final GrepOptions grepOptions = GrepOptions.builder().withGrepDefinitionInclusionRule(grepDefinitionInclusionRule).build();
+    final TableGrepFilter tableGrepFilter = new TableGrepFilter(grepOptions);
+
+    final Table table = new Table() {
+      @Override
+      public String getFullName() {
+        return "test_table";
+      }
+
+      @Override
+      public String getRemarks() {
+        return "test_remarks";
+      }
+
+      @Override
+      public String getDefinition() {
+        return "test_definition";
+      }
+
+      @Override
+      public Iterable<Column> getColumns() {
+        return Collections.emptyList();
+      }
+
+      @Override
+      public Iterable<Trigger> getTriggers() {
+        return Collections.emptyList();
+      }
+    };
+
+    assertThat(tableGrepFilter.test(table), is(false));
+  }
+}

--- a/schemacrawler-api/src/test/java/schemacrawler/test/utility/crawl/LightTable.java
+++ b/schemacrawler-api/src/test/java/schemacrawler/test/utility/crawl/LightTable.java
@@ -37,6 +37,7 @@ public final class LightTable implements Table {
   private final String name;
   private final List<Column> columns;
   private final Map<String, Object> attributes;
+  private final Collection<Trigger> triggers;
   private String definition;
   private String remarks;
 
@@ -45,6 +46,7 @@ public final class LightTable implements Table {
     this.name = requireNotBlank(name, "No table name provided");
     attributes = new HashMap<>();
     columns = new ArrayList<>();
+    triggers = new ArrayList<>();
   }
 
   public LightTable(final String name) {
@@ -55,6 +57,12 @@ public final class LightTable implements Table {
     final LightColumn column = new LightColumn(this, name);
     columns.add(column);
     return column;
+  }
+
+  public void addTrigger(final Trigger trigger) {
+    if (trigger != null) {
+      triggers.add(trigger);
+    }
   }
 
   @Override
@@ -99,7 +107,7 @@ public final class LightTable implements Table {
 
   @Override
   public List<Column> getColumns() {
-    return columns;
+    return new ArrayList<>(columns);
   }
 
   @Override
@@ -180,7 +188,7 @@ public final class LightTable implements Table {
 
   @Override
   public Collection<Trigger> getTriggers() {
-    return Collections.emptyList();
+    return new ArrayList<>(triggers);
   }
 
   @Override

--- a/schemacrawler-api/src/test/java/schemacrawler/test/utility/crawl/LightTable.java
+++ b/schemacrawler-api/src/test/java/schemacrawler/test/utility/crawl/LightTable.java
@@ -1,9 +1,5 @@
 package schemacrawler.test.utility.crawl;
 
-import static java.util.Objects.requireNonNull;
-import static us.fatehi.utility.Utility.isBlank;
-import static us.fatehi.utility.Utility.requireNotBlank;
-
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -12,7 +8,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-
+import static java.util.Objects.requireNonNull;
+import static us.fatehi.utility.Utility.isBlank;
+import static us.fatehi.utility.Utility.requireNotBlank;
+import static us.fatehi.utility.Utility.trimToEmpty;
 import schemacrawler.schema.Column;
 import schemacrawler.schema.ForeignKey;
 import schemacrawler.schema.Index;
@@ -38,6 +37,8 @@ public final class LightTable implements Table {
   private final String name;
   private final List<Column> columns;
   private final Map<String, Object> attributes;
+  private String definition;
+  private String remarks;
 
   public LightTable(final Schema schema, final String name) {
     this.schema = requireNonNull(schema, "No schema provided");
@@ -66,10 +67,7 @@ public final class LightTable implements Table {
     if (this == obj) {
       return true;
     }
-    if (obj == null) {
-      return false;
-    }
-    if (getClass() != obj.getClass()) {
+    if ((obj == null) || (getClass() != obj.getClass())) {
       return false;
     }
     final LightTable other = (LightTable) obj;
@@ -90,9 +88,8 @@ public final class LightTable implements Table {
   public <T> T getAttribute(final String name, final T defaultValue) throws ClassCastException {
     if (hasAttribute(name)) {
       return getAttribute(name);
-    } else {
-      return defaultValue;
     }
+    return defaultValue;
   }
 
   @Override
@@ -107,7 +104,7 @@ public final class LightTable implements Table {
 
   @Override
   public String getDefinition() {
-    return "";
+    return trimToEmpty(definition);
   }
 
   @Override
@@ -163,7 +160,7 @@ public final class LightTable implements Table {
 
   @Override
   public String getRemarks() {
-    return "";
+    return trimToEmpty(remarks);
   }
 
   @Override
@@ -286,8 +283,14 @@ public final class LightTable implements Table {
     attributes.put(name, value);
   }
 
+  public void setDefinition(String definition) {
+    this.definition = definition;
+  }
+
   @Override
-  public void setRemarks(final String remarks) {}
+  public void setRemarks(final String remarks) {
+    this.remarks = remarks;
+  }
 
   @Override
   public String toString() {

--- a/schemacrawler-api/src/test/java/schemacrawler/test/utility/crawl/LightTrigger.java
+++ b/schemacrawler-api/src/test/java/schemacrawler/test/utility/crawl/LightTrigger.java
@@ -1,0 +1,152 @@
+package schemacrawler.test.utility.crawl;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import static java.util.Objects.requireNonNull;
+import schemacrawler.schema.ActionOrientationType;
+import schemacrawler.schema.ConditionTimingType;
+import schemacrawler.schema.EventManipulationType;
+import schemacrawler.schema.NamedObject;
+import schemacrawler.schema.NamedObjectKey;
+import schemacrawler.schema.Schema;
+import schemacrawler.schema.Table;
+import schemacrawler.schema.Trigger;
+import schemacrawler.schemacrawler.Identifiers;
+
+public class LightTrigger implements Trigger {
+
+  private static final long serialVersionUID = -2552665161195438344L;
+
+  private final Schema schema;
+  private final String name;
+  private final Table table;
+  private String actionStatement;
+
+  public LightTrigger(final Table table, final String name) {
+    this.table = requireNonNull(table, "No table provided");
+    schema = table.getSchema();
+    this.name = name;
+  }
+
+  public void setActionStatement(String actionStatement) {
+    this.actionStatement = actionStatement;
+  }
+
+  @Override
+  public String getShortName() {
+    return name;
+  }
+
+  @Override
+  public boolean isParentPartial() {
+    return true;
+  }
+
+  @Override
+  public Schema getSchema() {
+    return schema;
+  }
+
+  @Override
+  public void withQuoting(Identifiers identifiers) {}
+
+  @Override
+  public String getFullName() {
+    return name;
+  }
+
+  @Override
+  public String getName() {
+    return name;
+  }
+
+  @Override
+  public NamedObjectKey key() {
+    return null;
+  }
+
+  @Override
+  public int compareTo(NamedObject o) {
+    return 0;
+  }
+
+  @Override
+  public <T> T getAttribute(String name) {
+    return null;
+  }
+
+  @Override
+  public <T> T getAttribute(String name, T defaultValue) throws ClassCastException {
+    return null;
+  }
+
+  @Override
+  public Map<String, Object> getAttributes() {
+    return null;
+  }
+
+  @Override
+  public boolean hasAttribute(String name) {
+    return false;
+  }
+
+  @Override
+  public <T> Optional<T> lookupAttribute(String name) {
+    return Optional.empty();
+  }
+
+  @Override
+  public void removeAttribute(String name) {}
+
+  @Override
+  public <T> void setAttribute(String name, T value) {}
+
+  @Override
+  public String getRemarks() {
+    return null;
+  }
+
+  @Override
+  public boolean hasRemarks() {
+    return false;
+  }
+
+  @Override
+  public void setRemarks(String remarks) {}
+
+  @Override
+  public Table getParent() {
+    return table;
+  }
+
+  @Override
+  public String getActionCondition() {
+    return null;
+  }
+
+  @Override
+  public int getActionOrder() {
+    return 0;
+  }
+
+  @Override
+  public ActionOrientationType getActionOrientation() {
+    return null;
+  }
+
+  @Override
+  public String getActionStatement() {
+    return actionStatement;
+  }
+
+  @Override
+  public ConditionTimingType getConditionTiming() {
+    return null;
+  }
+
+  @Override
+  public Set<EventManipulationType> getEventManipulationTypes() {
+    return null;
+  }
+}


### PR DESCRIPTION
Add a new test class `TableGrepFilterTest` to cover `TableGrepFilter`.

* Use JUnit 5 and Hamcrest matchers for assertions.
* Cover various scenarios for the `test` method in `TableGrepFilter`, including:
  - Matching and non-matching cases
  - Cases with and without invert match
  - Column and definition inclusion rules
* Ensure the new test class compiles and runs in Java 8.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/schemacrawler/SchemaCrawler?shareId=3429f697-0384-4b56-9862-7e2dd5e85adf).