### PR TITLE
fixing undeterministic behavior in UtilityTest.joinMapTest

### DIFF
--- a/schemacrawler-utility/src/test/java/us/fatehi/utility/test/UtilityTest.java
+++ b/schemacrawler-utility/src/test/java/us/fatehi/utility/test/UtilityTest.java
@@ -122,8 +122,12 @@ public class UtilityTest {
       {"BLUE", "#0000FF"}
     };
 
-    assertThat(
-        join(MapUtils.putAll(new HashMap<>(), map), ","), is("RED=null,null=#00FF00,BLUE=#0000FF"));
+    final Map<String, String> finalMap = new HashMap<>();
+    MapUtils.putAll(finalMap, map);
+    final String joined = join(finalMap, ",");
+
+    assertThat(Arrays.asList(joined.split(",")),
+        containsInAnyOrder("RED=null", "null=#00FF00", "BLUE=#0000FF"));
   }
 
   @Test


### PR DESCRIPTION
### **Make UtilityTest#joinMapTest order-agnostic (proof-of-concept)**

Note to maintainer: I understand SchemaCrawler is not currently accepting contributions due to copyright/patent considerations. I’m filing this as a suggestion with a tiny patch to illustrate the idea. Please feel free to rewrite from scratch.

**Purpose of this change**
Eliminate flakiness in schemacrawler-utility’s us.fatehi.utility.test.UtilityTest#joinMapTest caused by relying on non-deterministic Map iteration order when producing a joined string.
**The Issue**
When run normally—or under NonDex to perturb iteration order—the test can fail because the expected string fixes an order for entries of a HashMap:
[ERROR]   UtilityTest.joinMapTest:125
```
Expected: is "RED=null,null=#00FF00,BLUE=#0000FF"
     but: was "BLUE=#0000FF,null=#00FF00,RED=null"
```
Repro (from repo root):
```
mvn -pl schemacrawler-utility \
  edu.illinois:nondex-maven-plugin:2.1.7:nondex \
  -Dtest='us.fatehi.utility.test.UtilityTest#joinMapTest'

```
My Fix
Make the assertion order-agnostic so the test validates content rather than iteration order.
In commit 2f18230


Built the Map as before, produced the joined string, then Asserted that the three comma-separated segments appear in any order using containsInAnyOrder(...).


(See commit 2f18230f56c4b137bae0128fbf2f2d4348c0d2be for the actual change.) [GitHub](https://github.com/schemacrawler/SchemaCrawler/commit/2f18230f56c4b137bae0128fbf2f2d4348c0d2be)


**How I validated**
Reproduced the failure with the original assertion.


Applied the patch from 2f18230 and re-ran the test (and with NonDex); the flake no longer reproduced locally. [GitHub](https://github.com/schemacrawler/SchemaCrawler/commit/2f18230f56c4b137bae0128fbf2f2d4348c0d2be)