### PR TITLE
Fix flaky test schemacrawler.test.RoutineReferencesTest 

### DIFF
--- a/schemacrawler-text/src/main/java/schemacrawler/tools/traversal/SchemaTraverser.java
+++ b/schemacrawler-text/src/main/java/schemacrawler/tools/traversal/SchemaTraverser.java
@@ -32,7 +32,7 @@ public class SchemaTraverser {
   private Comparator<NamedObject> routinesComparator;
 
   public SchemaTraverser() {
-    tablesComparator = NamedObjectSort.natural;
+    tablesComparator = Comparator.comparing((NamedObject n) -> ((Table) n).getSchema().getFullName()).thenComparing(NamedObject::getName);
     routinesComparator = NamedObjectSort.natural;
   }
 

--- a/schemacrawler-text/src/test/resources/RoutineReferencesTest.schemaTextOutput.html
+++ b/schemacrawler-text/src/test/resources/RoutineReferencesTest.schemaTextOutput.html
@@ -986,11 +986,11 @@ along with the latest updated information</td>
 		<td colspan='3'></td>
 	</tr>
 	<tr>
-		<td colspan='2' class='name'>PUBLIC.BOOKS.BOOKS</td>
+		<td colspan='2' class='name'>PUBLIC.BOOKS.BOOKAUTHORS</td>
 		<td class='description right'>[table]</td>
 	</tr>
 	<tr>
-		<td colspan='2' class='name'>PUBLIC.BOOKS.BOOKAUTHORS</td>
+		<td colspan='2' class='name'>PUBLIC.BOOKS.BOOKS</td>
 		<td class='description right'>[table]</td>
 	</tr>
 	<tr>

--- a/schemacrawler-text/src/test/resources/RoutineReferencesTest.schemaTextOutput.text
+++ b/schemacrawler-text/src/test/resources/RoutineReferencesTest.schemaTextOutput.text
@@ -200,8 +200,8 @@ FK_PREVIOUSEDITION                                    [non-unique index]
 
 Used By Objects
 
-PUBLIC.BOOKS.BOOKS                                               [table]
 PUBLIC.BOOKS.BOOKAUTHORS                                         [table]
+PUBLIC.BOOKS.BOOKS                                               [table]
 
 Privileges and Grants
 


### PR DESCRIPTION
This PR modifies ```SchemaTraverser.java``` to sort tables by schema name then table name, ensuring consistent output order in ```RoutineReferencesTest``` and preventing flakiness under NonDex. I know you won't accept it as-is, but it can inspire a proper fix.